### PR TITLE
fix the commands required for build_sensorbee installation

### DIFF
--- a/source/tutorial/getting_started.rst
+++ b/source/tutorial/getting_started.rst
@@ -69,16 +69,16 @@ Everything necessary to try this tutorial is ready now except SensorBee. The
 next step is to build a custom ``sensorbee`` command that includes the plugins
 needed for this tutorial.
 
-Building a ``sensorbee`` Command
---------------------------------
+Building a ``sensorbee`` Executable
+-----------------------------------
 
-To build a ``sensorbee`` command, the ``build_sensorbee`` command needs to be
-installed::
+To build a ``sensorbee`` executable, the ``build_sensorbee`` program needs to
+be installed. To do so, issue the following command::
 
-    $ go get gopkg.in/sensorbee/sensorbee.v0/cmd/build_sensorbee
+    $ go get gopkg.in/sensorbee/sensorbee.v0/...
 
-This command is used to build a custom ``sensorbee`` executable with plugins
-provided by developers.
+The ``build_sensorbee`` program is used to build a custom ``sensorbee``
+executable with plugins provided by developers.
 
 Then, move to the directory that has configuration files previously copied from
 the tutorial package and execute ``build_sensorbee``::

--- a/source/tutorial/machine_learning.rst
+++ b/source/tutorial/machine_learning.rst
@@ -284,7 +284,7 @@ All requirements for this tutorial have been installed and set up. The next
 step is to install ``build_sensorbee``, then build and run the ``sensorbee``
 executable::
 
-    /path/to/sbml$ go get gopkg.in/sensorbee/sensorbee.v0/cmd/build_sensorbee
+    /path/to/sbml$ go get gopkg.in/sensorbee/sensorbee.v0/...
     /path/to/sbml$ build_sensorbee
     sensorbee_main.go
     /path/to/sbml$ ./sensorbee run -c sensorbee.yaml


### PR DESCRIPTION
Directly installing `build_sensorbee` using `go get` will fail as long as https://github.com/niemeyer/gopkg/pull/42 is not merged and deployed.