### PR TITLE
Add ./ to sensorbee command

### DIFF
--- a/source/tutorial/machine_learning.rst
+++ b/source/tutorial/machine_learning.rst
@@ -323,7 +323,7 @@ Troubleshooting
 If Kibana doesn't show the "Create" button, something may not be working
 properly. First, enter ``sensorbee shell`` to see SensorBee is working::
 
-    /path/to/sbml$ sensorbee shell -t twitter
+    /path/to/sbml$ ./sensorbee shell -t twitter
     twitter>
 
 Then, issue the following ``SELECT`` statement::


### PR DESCRIPTION
The default sensorbee command is removed, so I added missing `./` to all sensorbee command execution.
ref #40 