### PR TITLE
Fix description for build_sensorbee's --download-plugins option

### DIFF
--- a/source/ref/commands/build_sensorbee.rst
+++ b/source/ref/commands/build_sensorbee.rst
@@ -73,7 +73,7 @@ Flags and Options
 
         $ build_sensorbee -c /path/to/dir/special_build.yaml
 
-``--download-plugins {true | false}``
+``--download-plugins={true|false}``
 
     This option have to be ``true`` or ``false``. When the value is ``true``,
     ``build_sensorbee`` downloads (i.e. ``go get``) all plugins listed in


### PR DESCRIPTION
I fixed the description for `build_sensorbee`'s `--download-plugins` option.
Due to the behavior of the standard library `flag` package, `=` is necessary for bool options.

See https://github.com/urfave/cli/issues/358